### PR TITLE
fix : PHP8 json_decode() problem

### DIFF
--- a/src/Api/Serializers/ConversationSerializer.php
+++ b/src/Api/Serializers/ConversationSerializer.php
@@ -18,7 +18,8 @@ class ConversationSerializer extends AbstractSerializer
         }
 
         return [
-            'status' => json_decode($conversation->status),
+            //fix : json_decode() passed null problem
+            'status' => $conversation->status ? json_decode($conversation->status) : [],
             'createdAt' => $this->formatDate($conversation->created_at),
             'updatedAt' => $this->formatDate($conversation->created_at),
             'totalMessages' => $conversation->total_messages,


### PR DESCRIPTION
Today, when I was running the test plugin, I unexpectedly encountered an error. The operating environment was PHP8.2, and then I checked the code
ConversationSerializer.php line 21,
The json_decode() function passed null, which will cause an error in the PHP8 version because the first parameter of json_decode() is required to be a string type, and passing null does not meet the requirements.
